### PR TITLE
Upgrade serialize-javascript 3.0.0 to 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "core-js": "^3.6.4",
     "font-awesome": "^4.7.0",
     "jquery": "^3.5.0",
-    "lodash": "^4.17.19",
+    "lodash": "^4.17.20",
     "mathjs": "^7.0.0",
     "minimist": "^1.2.5",
     "ng-katex": "^1.3.1",
@@ -44,7 +44,7 @@
     "popper": "^1.0.1",
     "popper.js": "^1.16.1",
     "rxjs": "^6.5.4",
-    "serialize-javascript": "^3.0.0",
+    "serialize-javascript": "^3.1.0",
     "set-value": "^3.0.1",
     "tslib": "^1.10.0",
     "zone.js": "~0.10.2"


### PR DESCRIPTION
### Serialize-javascript from 3.0.0 to 3.0.1 
I decided to upgrade serialize-javascript as version 3.0.0 is vulnerable to **Arbitrary Code Injection** because affected version of this package are vulnerable to Arbitrary Code Injection. An object like` {"foo": /1"/, "bar": "a\"@__R-<UID>-0__@"}` would be serialized as `{"foo": /1"/, "bar": "a\/1"/}`, meaning an attacker could escape out of bar if they controlled both foo and bar and were able to guess the value of `<UID>`. UID is generated once on startup, is chosen using `Math.random()` and has a keyspace of roughly 4 billion.

### PoC
`eval('('+ serialize({"foo": /1" + console.log(1)/i, "bar": '"@__R-<UID>-0__@'}) + ')');`